### PR TITLE
Potential fix for code scanning alert no. 38: Full server-side request forgery

### DIFF
--- a/app.py
+++ b/app.py
@@ -517,6 +517,18 @@ def test_endpoint():
     data = request.json or {}
     token = data.get('token')
     url = data.get('url')
+    
+    # Validate the URL
+    from urllib.parse import urlparse
+    allowed_domains = ["example.com", "api.example.com"]
+    try:
+        parsed_url = urlparse(url)
+        if parsed_url.scheme not in ["http", "https"]:
+            return jsonify({"error": "Invalid URL scheme"}), 400
+        if parsed_url.hostname not in allowed_domains:
+            return jsonify({"error": "URL domain is not allowed"}), 400
+    except Exception as e:
+        return jsonify({"error": f"Invalid URL: {str(e)}"}), 400
     method = data.get('method', 'GET').upper()
     
     if not token:


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/38](https://github.com/eshanized/JWTKit/security/code-scanning/38)

To fix the SSRF vulnerability, we need to validate and restrict the `url` parameter to ensure it cannot be used to make unauthorized or malicious requests. The best approach is to maintain a whitelist of allowed domains or base URLs and verify that the user-provided `url` matches one of these allowed values. Additionally, we can parse the URL to ensure it does not point to private IP ranges or internal networks.

Steps to implement the fix:
1. Parse the user-provided `url` using Python's `urllib.parse` module to extract its components.
2. Validate the hostname against a predefined whitelist of allowed domains.
3. Optionally, resolve the hostname to an IP address and ensure it does not belong to private or internal IP ranges.
4. Reject the request if the `url` fails any of these checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
