### PR TITLE
Potential fix for code scanning alert no. 1: Except block handles 'BaseException'

### DIFF
--- a/backend/flask_app.py
+++ b/backend/flask_app.py
@@ -69,7 +69,7 @@ def docs():
     try:
         # Try to serve static documentation if available
         return send_from_directory('static', 'docs.html')
-    except:
+    except Exception:
         # Otherwise return JSON endpoints documentation
         endpoints = [
             {


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/1](https://github.com/eshanized/JWTKit/security/code-scanning/1)

To fix the issue, the bare `except:` block should be replaced with an `except Exception:` block. This ensures that only exceptions derived from `Exception` are caught, leaving `KeyboardInterrupt` and `SystemExit` to propagate as intended. This change will maintain the existing functionality while adhering to best practices.

The specific change will be made on line 72 of the file `backend/flask_app.py`. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
