### PR TITLE
Potential fix for code scanning alert no. 4: Unused local variable

### DIFF
--- a/app.py
+++ b/app.py
@@ -426,7 +426,7 @@ def jwks_spoofing():
             key_size=2048,
             backend=default_backend()
         )
-        public_key = private_key.public_key()
+
         
         # Create a unique key ID
         kid = f"attacker-key-{int(time.time())}"


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/4](https://github.com/eshanized/JWTKit/security/code-scanning/4)

To fix the issue, we should remove the assignment to the `public_key` variable entirely, as it is not used in the code. Since the right-hand side of the assignment (`private_key.public_key()`) does not have any side effects, it is safe to delete the entire line without affecting the functionality of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
