### PR TITLE
Potential fix for code scanning alert no. 22: Unused import

### DIFF
--- a/backend/key_manager.py
+++ b/backend/key_manager.py
@@ -12,7 +12,7 @@ import base64
 import logging
 import hashlib
 from typing import Dict, List, Optional, Tuple, Union, Any
-from datetime import datetime, timedelta
+from datetime import datetime
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa, ec, ed25519
 from cryptography.hazmat.primitives.serialization import load_pem_private_key


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/22](https://github.com/eshanized/JWTKit/security/code-scanning/22)

To fix the issue, we will remove the unused `timedelta` import from the `from datetime import datetime, timedelta` statement on line 15. This will eliminate the unnecessary dependency and improve code clarity without affecting functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
