### PR TITLE
Potential fix for code scanning alert no. 165: Full server-side request forgery

### DIFF
--- a/app.py
+++ b/app.py
@@ -529,6 +529,12 @@ def test_endpoint():
     # Define allowed domains in one place
     allowed_domains = {"example.com", "api.example.com"}
 
+    # Validate the domain of the provided URL
+    from urllib.parse import urlparse
+    parsed_url = urlparse(url)
+    if parsed_url.netloc not in allowed_domains:
+        return jsonify({"error": "URL domain is not allowed"}), 400
+
     # Define allowed ports for HTTP/HTTPS
     allowed_ports = {80, 443}
 


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/165](https://github.com/eshanized/JWTKit/security/code-scanning/165)

To fix the issue, we need to validate the `url` parameter against the `allowed_domains` list before making the HTTP request. This involves:
1. Parsing the `url` to extract its domain.
2. Checking if the extracted domain is in the `allowed_domains` list.
3. Rejecting the request with an appropriate error message if the domain is not allowed.

This fix ensures that only requests to explicitly permitted domains are processed, mitigating the SSRF vulnerability.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
