### PR TITLE
Potential fix for code scanning alert no. 5: Unused local variable

### DIFF
--- a/backend/attack_simulator.py
+++ b/backend/attack_simulator.py
@@ -89,7 +89,7 @@ class JWTSecurityTester:
             # Convert the public key to the format needed
             try:
                 # Try to parse the key (assuming PEM format)
-                public_key_obj = serialization.load_pem_public_key(
+                serialization.load_pem_public_key(
                     public_key.encode(),
                     backend=default_backend()
                 )


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/5](https://github.com/eshanized/JWTKit/security/code-scanning/5)

To fix the issue, we will remove the unused variable `public_key_obj` and replace its assignment with a direct call to `serialization.load_pem_public_key`. This ensures that the key parsing operation is retained (if it serves a validation purpose) while eliminating the unused variable. No other changes to the functionality of the method are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
