### PR TITLE
Potential fix for code scanning alert no. 6: Unused local variable

### DIFF
--- a/backend/attack_simulator.py
+++ b/backend/attack_simulator.py
@@ -105,7 +105,7 @@ class JWTSecurityTester:
                 encoded_payload = base64.b64encode(json.dumps(payload).encode()).decode().rstrip('=')
                 
                 # Create signature using the public key as the secret
-                signature_part = f"{encoded_header}.{encoded_payload}"
+                
                 forged_signature = jwt.encode(
                     payload, 
                     public_key_bytes, 


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/6](https://github.com/eshanized/JWTKit/security/code-scanning/6)

To fix the issue, we will remove the assignment to the unused variable `signature_part` on line 108. Since the right-hand side of the assignment does not have any side effects, it can be safely deleted without impacting the rest of the code. This will eliminate the unused variable and improve code clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
