### PR TITLE
Potential fix for code scanning alert no. 7: Unused local variable

### DIFF
--- a/backend/attack_simulator.py
+++ b/backend/attack_simulator.py
@@ -220,7 +220,7 @@ class JWTSecurityTester:
             public_key = private_key.public_key()
             
             # Get key components for the JWK
-            private_numbers = private_key.private_numbers()
+# Removed unused variable assignment
             public_numbers = public_key.public_numbers()
             
             # Create a unique key ID


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/7](https://github.com/eshanized/JWTKit/security/code-scanning/7)

To fix the issue, we should remove the assignment of the `private_numbers` variable entirely, as it is not used anywhere in the method. Since the right-hand side of the assignment does not have any side effects, it is safe to delete the line without affecting the functionality of the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
