### PR TITLE
Potential fix for code scanning alert no. 8: Unused local variable

### DIFF
--- a/backend/attack_simulator.py
+++ b/backend/attack_simulator.py
@@ -787,7 +787,6 @@ class JWTTester:
         try:
             # Extract the header and payload
             header_b64, payload_b64, signature_b64 = token.split('.')
-            message = f"{header_b64}.{payload_b64}"
             
             # Try each word in the wordlist
             for secret in wordlist:


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/8](https://github.com/eshanized/JWTKit/security/code-scanning/8)

To fix the issue, we should remove the unused variable `message` from the code. Since the assignment of `message` does not have any side effects (it is a simple string concatenation), we can safely delete the line where it is defined. This will eliminate the unused variable and improve code clarity without affecting the functionality of the method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
