### PR TITLE
Potential fix for code scanning alert no. 110: Except block handles 'BaseException'

### DIFF
--- a/backend/jwt_utils.py
+++ b/backend/jwt_utils.py
@@ -366,7 +366,7 @@ class JWTUtils:
                         "key_index": i,
                         "message": "Secret found! Token can be forged."
                     }
-            except:
+            except Exception:
                 continue
         
         return {


### PR DESCRIPTION
Potential fix for [https://github.com/eshanized/JWTKit/security/code-scanning/110](https://github.com/eshanized/JWTKit/security/code-scanning/110)

To fix the issue, replace the bare `except:` block with an `except Exception:` block to catch only standard exceptions. This ensures that special exceptions like `KeyboardInterrupt` and `SystemExit` are not inadvertently caught. If there is a need to handle these special exceptions, they should be caught explicitly in separate `except` blocks.

The changes will be made in the `attempt_token_forgery` method of the `JWTUtils` class in the file `backend/jwt_utils.py`. Specifically, the `except:` block on line 369 will be replaced with `except Exception:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
